### PR TITLE
Multi-Argument Folder Creation. With the new update, you can now crea…

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,26 @@ to get help run:
 ```bash
 npx react-cli-builder --help
 ```
+
+## Multi-Argument Folder Creation
+
+With the new update, you can now create multiple folders in one command:
+```bash
+npx create-folders <folder1> <folder2> ...
+```
+Example:
+
+```bash
+npx create-folders auth lib pages
+```
+This command creates the auth, lib, and pages folders along with their respective files.
+## You can also create a single folder 
+```bash
+npx create-folders <folder1>
+```
+Example:
+
+```bash
+npx create-folders auth 
+```
+this will create a folder called auth

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "create-basic": "dist/app/basic.js",
         "create-components": "dist/script/create_components_folder.js",
         "create-context": "dist/script/create_context_folder.js",
+        "create-folders": "dist/script/create_multiple_folders.js",
         "create-hook": "dist/script/create_hook_folder.js",
         "create-lib": "dist/script/create_lib_folder.js",
         "create-pages": "dist/script/create_pages_folder.js",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "create-redux-saga": "./dist/script/create_redux_saga.js",
     "create-tailwind": "./dist/script/create_tailwind_folder.js",
     "create-basic": "./dist/app/basic.js",
-    "react-cli-builder": "./dist/flags/flags.js"
+    "react-cli-builder": "./dist/flags/flags.js",
+    "create-folders": "./dist/script/create_multiple_folders.js"
   },
   "keywords": [
     "react",

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -1,0 +1,77 @@
+// auth.ts
+
+const API_URL = "http://localhost:3000/api"; // Replace with your backend API URL
+
+interface RegisterResponse {
+  message: string;
+}
+
+interface LoginResponse {
+  token: string;
+}
+
+export const register = async (
+  username: string,
+  password: string
+): Promise<void> => {
+  try {
+    const response = await fetch(API_URL + "/register", {
+      // Using + for concatenation
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ username, password }),
+    });
+
+    if (!response.ok) {
+      throw new Error("Registration failed");
+    }
+
+    const data: RegisterResponse = await response.json();
+    console.log(data.message);
+  } catch (error) {
+    console.error("Error:", error);
+  }
+};
+
+export const login = async (
+  username: string,
+  password: string
+): Promise<void> => {
+  try {
+    const response = await fetch(API_URL + "/login", {
+      // Using + for concatenation
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ username, password }),
+    });
+
+    if (!response.ok) {
+      throw new Error("Login failed");
+    }
+
+    const data: LoginResponse = await response.json();
+    localStorage.setItem("token", data.token); // Save token in local storage
+    console.log("Login successful:", data);
+  } catch (error) {
+    console.error("Error:", error);
+  }
+};
+
+export const logout = (): void => {
+  localStorage.removeItem("token"); // Remove token on logout
+  console.log("Logged out successfully");
+};
+
+export const getCurrentUser = (): any => {
+  const token = localStorage.getItem("token");
+  if (!token) {
+    return null;
+  }
+  // Optionally decode the token to get user info
+  const payload = JSON.parse(atob(token.split(".")[1]));
+  return payload;
+};

--- a/src/pages/default.tsx
+++ b/src/pages/default.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const App = () => {
+  return <></>;
+};
+
+export default App;

--- a/src/questions/question.ts
+++ b/src/questions/question.ts
@@ -9,18 +9,7 @@ export const createScript = async (
   ts: Folder
 ): Promise<void> => {
   try {
-    const questions = await inquirer.prompt([
-      {
-        type: "confirm",
-        name: "isTypescript",
-        message: "Are you using Typescript?",
-        default: false,
-      },
-    ]);
-
-    const { isTypescript } = questions;
-
-    if (!isTypescript) {
+    if (!true) {
       await createNoCodeFileJs(jsx);
     } else {
       await createNoCodeFileTs(tsx);

--- a/src/script/create_multiple_folders.ts
+++ b/src/script/create_multiple_folders.ts
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+/*
+Add a new section describing the multi-argument support:
+
+## Multi-Argument Folder Creation
+
+With the new update, you can now create multiple folders in one command:
+```bash
+npm create-folders <folder1> <folder2> ...
+
+Example:
+
+npm create-folders auth lib pages
+
+This command creates the auth, lib, and pages folders along with their respective files.
+*/
+
+import {
+  folderAuthJs,
+  folderAuthTs,
+  folderApiJs,
+  folderApiTs,
+  folderContextJs,
+  folderContextTs,
+  folderPagesJs,
+  folderPagesTs,
+  folderCompJs,
+  folderCompTs,
+  folderLibJs,
+  folderLibTs,
+  folderStoreJs,
+  folderStoreTs,
+  folderUtilsJs,
+  folderUtilsTs,
+  folderReduxStoreJs,
+  folderReduxStoreTs,
+  folderReduxSliceJs,
+  folderReduxSliceTs,
+  folderReduxSagaJs,
+  folderReduxSagaTs,
+  folderHookJs,
+  folderHookTs,
+  folderTs,
+} from "../class/objects";
+import { SingleFolder } from "../libs/single_folder";
+import { createScript } from "../questions/question";
+
+// Type definition for folder objects
+type FolderMappings = {
+  [key: string]: SingleFolder[];
+};
+
+// Mapping for folder creation objects
+const folderMappings: FolderMappings = {
+  auth: [folderAuthJs, folderAuthTs],
+  api: [folderApiJs, folderApiTs],
+  context: [folderContextJs, folderContextTs],
+  pages: [folderPagesJs, folderPagesTs],
+  components: [folderCompJs, folderCompTs],
+  lib: [folderLibJs, folderLibTs],
+  store: [folderStoreJs, folderStoreTs],
+  utils: [folderUtilsJs, folderUtilsTs],
+  reduxStore: [folderReduxStoreJs, folderReduxStoreTs],
+  reduxSlice: [folderReduxSliceJs, folderReduxSliceTs],
+  reduxSaga: [folderReduxSagaJs, folderReduxSagaTs],
+  hook: [folderHookJs, folderHookTs],
+  types: [folderTs],
+};
+
+// Function to create the requested folders
+const createFolderScript = (folders: string[]): void => {
+  folders.forEach((folder) => {
+    if (folderMappings[folder]) {
+      folderMappings[folder].forEach((folderObj) => {
+        createScript(folderObj, folderObj, folderObj);
+      });
+    } else {
+      console.log(`Unknown folder type: ${folder}`);
+    }
+  });
+};
+
+// Retrieve arguments passed in the command (excluding 'create-folders' command itself)
+const args = process.argv.slice(2);
+createFolderScript(args);


### PR DESCRIPTION
## Multi-Argument Folder Creation

With the new update, you can now create multiple folders in one command:
```bash
npx create-folders <folder1> <folder2> ...
```
Example:

```bash
npx create-folders auth lib pages
```
This command creates the auth, lib, and pages folders along with their respective files.

## You can also create a single folder 
```bash
npx create-folders <folder1>
```
Example:

```bash
npx create-folders auth 
```
this will create a folder called auth